### PR TITLE
ci: extend workflow matrix to include php 8.2, 8.3 and 8.4

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -51,6 +51,33 @@ jobs:
             composer_update_flags: '--prefer-lowest --prefer-stable'
             php_ini: 'xdebug.coverage_enable=On'
             name: 'PHP 8.1 with lowest stable deps'
+          - php: 8.2
+            allow_fail: true
+            php_ini: 'xdebug.coverage_enable=On'
+            name: 'PHP 8.2 with latest deps'
+          - php: 8.2
+            allow_fail: true
+            composer_update_flags: '--prefer-lowest --prefer-stable'
+            php_ini: 'xdebug.coverage_enable=On'
+            name: 'PHP 8.2 with lowest stable deps'
+          - php: 8.3
+            allow_fail: true
+            php_ini: 'xdebug.coverage_enable=On'
+            name: 'PHP 8.3 with latest deps'
+          - php: 8.3
+            allow_fail: true
+            composer_update_flags: '--prefer-lowest --prefer-stable'
+            php_ini: 'xdebug.coverage_enable=On'
+            name: 'PHP 8.3 with lowest stable deps'
+          - php: 8.4
+            allow_fail: true
+            php_ini: 'xdebug.coverage_enable=On'
+            name: 'PHP 8.4 with latest deps'
+          - php: 8.4
+            allow_fail: true
+            composer_update_flags: '--prefer-lowest --prefer-stable'
+            php_ini: 'xdebug.coverage_enable=On'
+            name: 'PHP 8.4 with lowest stable deps'
 
     runs-on: ubuntu-latest
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Support Laravel 12 [PR#23](https://github.com/JsonMapper/LaravelPackage/pull/23). Thanks to [laravel-shift](https://github.com/laravel-shift) for creating the PR.
+- Extend workflow matrix to include PHP 8.2, 8.3 and 8.4 [PR#24](https://github.com/JsonMapper/LaravelPackage/pull/24)
 
 ## [2.5.0] - 2024-04-05 
 ### Added


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/build.yaml` file to add support for testing with newer PHP versions. The most important changes are the addition of job configurations for PHP versions 8.2, 8.3, and 8.4 with both the latest and lowest stable dependencies.

Updates to PHP version support in CI workflow:

* Added job configuration for PHP 8.2 with the latest dependencies and allowed failures. (`.github/workflows/build.yaml`: [.github/workflows/build.yamlR54-R80](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1R54-R80))
* Added job configuration for PHP 8.2 with the lowest stable dependencies and allowed failures. (`.github/workflows/build.yaml`: [.github/workflows/build.yamlR54-R80](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1R54-R80))
* Added job configuration for PHP 8.3 with the latest dependencies and allowed failures. (`.github/workflows/build.yaml`: [.github/workflows/build.yamlR54-R80](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1R54-R80))
* Added job configuration for PHP 8.3 with the lowest stable dependencies and allowed failures. (`.github/workflows/build.yaml`: [.github/workflows/build.yamlR54-R80](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1R54-R80))
* Added job configuration for PHP 8.4 with both the latest and lowest stable dependencies and allowed failures. (`.github/workflows/build.yaml`: [.github/workflows/build.yamlR54-R80](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1R54-R80))